### PR TITLE
Added AdditionalCommands feature for tab-complete suggestions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.jadedmc</groupId>
     <artifactId>CommandBlocker</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <packaging>jar</packaging>
 
     <name>CommandBlocker</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.jadedmc</groupId>
     <artifactId>CommandBlocker</artifactId>
-    <version>1.7.2</version>
+    <version>1.7.1</version>
     <packaging>jar</packaging>
 
     <name>CommandBlocker</name>

--- a/src/main/java/net/jadedmc/commandblocker/AdditionalCommandHandler.java
+++ b/src/main/java/net/jadedmc/commandblocker/AdditionalCommandHandler.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of CommandBlocker, licensed under the MIT License.
+ *
+ *  Copyright (c) JadedMC
+ *  Copyright (c) contributors
+ */
+package net.jadedmc.commandblocker;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Registers AdditionalCommands on the server's CommandMap so the client
+ * recognizes them in tab-complete and doesn't show "Unknown command" error.
+ */
+public class AdditionalCommandHandler {
+    private static final String FALLBACK_PREFIX = "commandblocker";
+
+    private final CommandBlockerPlugin plugin;
+    private final List<AdditionalCommand> registered = new ArrayList<>();
+    private final CommandMap commandMap;
+
+    public AdditionalCommandHandler(@NotNull final CommandBlockerPlugin plugin) {
+        this.plugin = plugin;
+        this.commandMap = resolveCommandMap();
+        registerAll();
+    }
+
+    private CommandMap resolveCommandMap() {
+        try {
+            final Field field = findField(Bukkit.getServer().getClass(), "commandMap");
+            if(field == null) {
+                plugin.getLogger().warning("Could not locate commandMap field. AdditionalCommands will not work.");
+                return null;
+            }
+            field.setAccessible(true);
+            return (CommandMap) field.get(Bukkit.getServer());
+        } catch (final IllegalAccessException exception) {
+            plugin.getLogger().warning("Could not access CommandMap: " + exception.getMessage());
+            return null;
+        }
+    }
+
+    public void registerAll() {
+        if(commandMap == null) return;
+
+        for(final String name : plugin.getConfigManager().getAdditionalCommands()) {
+            registerCommand(name);
+        }
+
+        refreshOnlinePlayers();
+    }
+
+    private void registerCommand(@NotNull final String rawName) {
+        final String name = rawName.toLowerCase().trim();
+        if(name.isEmpty()) return;
+        if(commandMap.getCommand(name) != null) return;
+
+        final AdditionalCommand cmd = new AdditionalCommand(name);
+        commandMap.register(FALLBACK_PREFIX, cmd);
+        registered.add(cmd);
+    }
+
+    public void unregisterAll() {
+        if(commandMap == null || registered.isEmpty()) return;
+
+        try {
+            final Field knownCommandsField = findField(commandMap.getClass(), "knownCommands");
+            if(knownCommandsField == null) {
+                plugin.getLogger().warning("Could not find knownCommands field. AdditionalCommands may linger until restart.");
+                return;
+            }
+            knownCommandsField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            final Map<String, Command> knownCommands = (Map<String, Command>) knownCommandsField.get(commandMap);
+
+            for(final AdditionalCommand cmd : registered) {
+                final String name = cmd.getName();
+                if(knownCommands.get(name) == cmd) {
+                    knownCommands.remove(name);
+                }
+                if(knownCommands.get(FALLBACK_PREFIX + ":" + name) == cmd) {
+                    knownCommands.remove(FALLBACK_PREFIX + ":" + name);
+                }
+                cmd.unregister(commandMap);
+            }
+            registered.clear();
+            refreshOnlinePlayers();
+        } catch (final IllegalAccessException exception) {
+            plugin.getLogger().warning("Could not unregister AdditionalCommands: " + exception.getMessage());
+        }
+    }
+
+    private Field findField(@NotNull Class<?> type, @NotNull final String name) {
+        while(type != null && type != Object.class) {
+            try {
+                return type.getDeclaredField(name);
+            } catch (final NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    private void refreshOnlinePlayers() {
+        for(final Player player : Bukkit.getOnlinePlayers()) {
+            player.updateCommands();
+        }
+    }
+
+    public void reload() {
+        unregisterAll();
+        registerAll();
+    }
+
+    /**
+     * Marker subclass so we can reliably identify commands registered by this plugin.
+     */
+    private static final class AdditionalCommand extends Command {
+        private AdditionalCommand(@NotNull final String name) {
+            super(name);
+        }
+
+        @Override
+        public boolean execute(@NotNull final CommandSender sender, @NotNull final String label, @NotNull final String[] args) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/net/jadedmc/commandblocker/CommandBlockerPlugin.java
+++ b/src/main/java/net/jadedmc/commandblocker/CommandBlockerPlugin.java
@@ -36,6 +36,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class CommandBlockerPlugin extends JavaPlugin {
     private HookManager hookManager;
     private ConfigManager configManager;
+    private AdditionalCommandHandler additionalCommandHandler;
 
     /**
      * Runs when the plugin is enabled.
@@ -47,6 +48,7 @@ public final class CommandBlockerPlugin extends JavaPlugin {
 
         configManager = new ConfigManager(this);
         hookManager = new HookManager(this);
+        additionalCommandHandler = new AdditionalCommandHandler(this);
 
         getCommand("commandblocker").setExecutor(new CommandBlockerCMD(this));
 
@@ -61,8 +63,16 @@ public final class CommandBlockerPlugin extends JavaPlugin {
      */
     @Override
     public void onDisable() {
+        if(additionalCommandHandler != null) {
+            additionalCommandHandler.unregisterAll();
+        }
+
         // Disables ChatUtils. Required to prevent memory leaks with the Adventure Library.
         ChatUtils.disable();
+    }
+
+    public AdditionalCommandHandler getAdditionalCommandHandler() {
+        return this.additionalCommandHandler;
     }
 
     /**
@@ -99,5 +109,8 @@ public final class CommandBlockerPlugin extends JavaPlugin {
      */
     public void reload() {
         this.configManager.reloadConfig();
+        if(this.additionalCommandHandler != null) {
+            this.additionalCommandHandler.reload();
+        }
     }
 }

--- a/src/main/java/net/jadedmc/commandblocker/ConfigManager.java
+++ b/src/main/java/net/jadedmc/commandblocker/ConfigManager.java
@@ -40,6 +40,7 @@ public class ConfigManager {
     private FileConfiguration config;
     private final File configFile;
     private final Collection<String> commands = new HashSet<>();
+    private final Collection<String> additionalCommands = new HashSet<>();
 
     /**
      * Loads or Creates configuration files.
@@ -58,6 +59,10 @@ public class ConfigManager {
         return this.commands;
     }
 
+    public Collection<String> getAdditionalCommands() {
+        return this.additionalCommands;
+    }
+
     /**
      * Get the config.yml FileConfiguration.
      * @return config.yml FileConfiguration.
@@ -74,6 +79,14 @@ public class ConfigManager {
 
             this.commands.add(command);
         }
+
+        for(String command : this.config.getStringList("AdditionalCommands")) {
+            if(command.startsWith("/")) {
+                command = command.substring(1);
+            }
+
+            this.additionalCommands.add(command);
+        }
     }
 
     /**
@@ -81,6 +94,7 @@ public class ConfigManager {
      */
     public void reloadConfig() {
         this.commands.clear();
+        this.additionalCommands.clear();
         config = YamlConfiguration.loadConfiguration(configFile);
         loadCommands();
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,6 +42,14 @@ Commands:
   - /ver
   - /version
 
+# Additional commands to show in tab-complete suggestions.
+# Useful for custom commands that are not registered on the server but you want to appear as hints.
+# Only works in BLACKLIST and HIDE modes.
+AdditionalCommands:
+  - /help
+  - /kits
+  - /spawn
+
 # Hides all commands that have a ':' in them.
 # Such as: /bukkit:version, /minecraft:tp, etc
 HideColonCommands: false


### PR DESCRIPTION
**Subject:** Added support for custom command completion in BLACKLIST mode

Hello JadedMC! Your plugin was exactly what I was looking for and has been extremely helpful.

I've added a new feature: when the mode is set to **BLACKLIST or HIDE**, it now allows tab-completion for custom commands that aren't officially registered on the server.

No pressure to merge this if it doesn't align with your plans for the plugin. Thanks for the great work!